### PR TITLE
HTTP 303 Support

### DIFF
--- a/webserver/src/bmws.c
+++ b/webserver/src/bmws.c
@@ -42,7 +42,6 @@
 static void sigHandler();
 static int allowRemoteConnect, allowRemoteAdmin;
 static int isLocalConnection(SOCKET socket);
-struct serverInfo ServerInfo;
 
 static void web(SOCKET fd){
  // This gets run after we fork() for the client request
@@ -176,16 +175,6 @@ int main(){
 	signal(SIGTERM, sigHandler);	// Trap termination requests from the system
 
     readDbConfig();
-
-    // Save who we are
-    ServerInfo.port = port;
-    if( allowRemoteConnect ){
-        char hostname[SMALL_BUFSIZE];
-        gethostname(hostname,SMALL_BUFSIZE);
-        ServerInfo.hostname = strdup(hostname);
-    } else {
-        ServerInfo.hostname = strdup("localhost");
-    }
 
     listener = setupListener();
 

--- a/webserver/src/bmws.h
+++ b/webserver/src/bmws.h
@@ -55,12 +55,6 @@
 #define HEADER_CONTENT_TYPE "Content-Type"
 #define HTTP_EOL "\r\n"
 
-struct serverInfo{
-    char* hostname;
-    int port;
-};
-extern struct serverInfo ServerInfo;
-
 struct HttpResponse{
     int   code;
     char* msg;
@@ -120,7 +114,7 @@ void writeTextArrayToJson(SOCKET fd, char* key, char** values);
 void writeNumValueToJson(SOCKET fd, char* key, BW_INT value);
 void writeSyncData(SOCKET fd, struct Data* data);
 void writeHeadersOk(SOCKET fd, char* contentType, int endHeaders);
-void writeHeadersSeeOther(SOCKET fd, char* newPath, int endHeaders);
+void writeHeadersSeeOther(SOCKET fd, struct Request* req, int endHeaders);
 void writeHeadersNotFound(SOCKET fd, char* file);
 void writeHeadersForbidden(SOCKET fd, char* request);
 void writeHeadersNotAllowed(SOCKET fd, char* httpMethod);

--- a/webserver/src/handleFile.c
+++ b/webserver/src/handleFile.c
@@ -246,22 +246,28 @@ void processFileRequest(SOCKET fd, struct Request* req, struct NameValuePair* su
         }
 
     } else {
-     // We got the file, write out the headers and then send the content
-	if ( redirect ){
-	// Was the initial request only for "/" ?
-		writeHeadersSeeOther(fd, path, TRUE);
-	} else {
-        	writeHeadersOk(fd, mimeType->contentType, TRUE);
-	}
+        // We got the file, write out the headers and then send the content
+        if ( redirect ){
+            // Was the initial request only for "/" ?
+            struct NameValuePair* param = req->headers;
+            while (param != NULL){
+                if( strcmp(param->name, "Host") == 0 ) {
+                    writeHeadersSeeOther(fd, req, TRUE);
+                }
+                param = param->next;
+	    }
+        } else {
+            writeHeadersOk(fd, mimeType->contentType, TRUE);
+        }
         if (substPairs == NULL){
 	        int rc;
 	        char buffer[BUFSIZE];
 	        while ( (rc = fread(buffer, 1, BUFSIZE, fp)) > 0 ) {
 	           	writeData(fd, buffer, rc);
 	        }
-	    } else {
+        } else {
 	    	doSubs(fd, fp, substPairs);
-	    }
+     }
         fclose(fp);
     }
 

--- a/webserver/src/httpRequest.c
+++ b/webserver/src/httpRequest.c
@@ -137,16 +137,15 @@ struct Request* parseRequest(char* requestTxt){
  // Allocates a new Request struct and populates it with the contents of the request
     char httpMethod[BUFSIZE];
     char httpResource[BUFSIZE];
+    char httpHeader[BUFSIZE];
 
-	if (isLogDebug()){
-		logMsg(LOG_DEBUG, "Request: %s", requestTxt);
-	}
-	
+    if (isLogDebug()){
+	logMsg(LOG_DEBUG, "Request: %s", requestTxt);
+    }
+
  // Extract the HTTP method and resource
-    sscanf(requestTxt, "%s %s %*s", httpMethod, httpResource);
-
+    sscanf(requestTxt, "%s %s HTTP%*4c %2056c", httpMethod, httpResource, httpHeader);
     struct Request* request = malloc(sizeof(struct Request));
-
     char* path;
     char* paramPair;
     char* paramName;
@@ -155,7 +154,7 @@ struct Request* parseRequest(char* requestTxt){
     char* httpResourceCopy = strdupa(httpResource);
     int paramNameLen;
 
-	request->method  = strdup(httpMethod);
+    request->method  = strdup(httpMethod);
     request->params  = NULL;
     request->headers = NULL;
 
@@ -169,26 +168,25 @@ struct Request* parseRequest(char* requestTxt){
         request->path = strdup(path);
 
      // Split the path into 'name=value' parts
-        while (1) {
+        while(1){
             paramPair = strtok(NULL, "&");
- 
+
             if (paramPair == NULL){
              // Reached the end of the parameter list
-                break;                                      
-                
+                break;
+
             } else {
             	paramEquals = strchr(paramPair, '=');
             	if (paramEquals == NULL){
             	 // There was no '=' sign in this part, so ignore it
             		continue;
-            		
-            	} else {
+          	} else {
             	 // Get the part before the '=' character
             		paramNameLen = paramEquals - paramPair;
             		paramName = malloc(paramNameLen + 1);
             		strncpy(paramName, paramPair, paramNameLen + 1);
             		paramName[paramNameLen] = 0;
-            		
+
 	            	if (strcmp(paramEquals, "=") == 0){
 	            	 // No value was supplied - this is valid in certain cases (eg RSS hostname update from prefs page)
 	            		paramValue = strdup("");
@@ -196,11 +194,11 @@ struct Request* parseRequest(char* requestTxt){
 	            		paramValue = strdup(paramEquals + 1);
 	            	}
             	}
-            	
+
  	           	char* unescapedValue = unescapeValue(paramValue);
                 struct NameValuePair* param = makeNameValuePair(paramName, unescapedValue);
 				appendNameValuePair(&(request->params), param);
-				
+
 			 // These are all malloced above, and copied by makeNameValuePair(), so free them here
 				free(unescapedValue);
 				free(paramName);
@@ -209,10 +207,28 @@ struct Request* parseRequest(char* requestTxt){
         }
     }
 
-	if (isLogInfo()){
-		logRequest(request);
-	}
-	
+    char* headerName;
+    char* headerValue;
+    char* headers = strtok(requestTxt,HTTP_EOL);
+    // Extract the headers one at a time, and store them
+    while(1){
+	headerName = strtok(NULL, ": ");
+        headerValue = strtok(NULL, HTTP_EOL);
+
+        if( headerName == NULL || headerValue == NULL ){
+            break;
+        } else {
+            // Strip any leading whitespace
+            while( *headerName == ' ' || *headerName == '\n' || *headerName == '\r' ) headerName++;
+            while( *headerValue == ' ' ) headerValue++;
+            struct NameValuePair* header = makeNameValuePair(headerName, headerValue);
+            appendNameValuePair(&(request->headers), header);
+        }
+    }
+
+    if (isLogInfo()){
+	logRequest(request);
+    }
     return request;
 }
 
@@ -221,8 +237,13 @@ static void logRequest(struct Request* request){
 	struct NameValuePair* param = request->params;
 	while (param != NULL){
 		logMsg(LOG_INFO, "        %s=%s", param->name, param->value);
-		param = param->next;	
+		param = param->next;
 	}
+	param = request->headers;
+        while (param != NULL){
+                logMsg(LOG_INFO, "        %s=%s", param->name, param->value);
+                param = param->next;
+        }
 }
 
 void freeRequest(struct Request* request){


### PR DESCRIPTION
Hey,

I run bitmeteros behind an Apache2 Reverse Proxy and noticed Apache treats requests missing a trailing slash on the URI as a file and thus displays the index.html output request it gets from the bmws incorrectly to the user (as in not working).

Tossing a 303 corrects this and doesn't break any current behavior. Requests for "/" now get served a 303 pointing them to "http://servname:port/index.html" or the mobile version if requested. Server name is pulled based on if remote connects are allowed or not.
